### PR TITLE
readme note for issue #28 - Windows repository path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ Metacello new
 	repository: 'gitfiletree:///my/path/to/dynacase/repository';
 	load.
 ```
+Windows note: Use forward slashes (/) even on Windows. For example
+```
+    repository: 'gitfiletree:///C:/Users/Username/Pharo/dynacase/repository';
+```


### PR DESCRIPTION
Issue #28 - Readme note about usage of gitfiletree repository path on
windows.